### PR TITLE
chore(sdk): add groupings and automerge minor updates

### DIFF
--- a/sdk.json
+++ b/sdk.json
@@ -4,7 +4,10 @@
   "extends": [
     "local>happyvertical/renovate-config",
     "local>happyvertical/renovate-config:monorepo",
-    "local>happyvertical/renovate-config:pnpm"
+    "local>happyvertical/renovate-config:pnpm",
+    "local>happyvertical/renovate-config//groups/ai-sdks",
+    "local>happyvertical/renovate-config//groups/typescript-tools",
+    "local>happyvertical/renovate-config//groups/database"
   ],
   "labels": ["dependencies", "renovate", "sdk"],
   "packageRules": [
@@ -20,14 +23,8 @@
       "labels": ["dependencies", "major", "needs-review"]
     },
     {
-      "description": "Automerge all patch updates",
-      "matchUpdateTypes": ["patch"],
-      "automerge": true
-    },
-    {
-      "description": "Automerge minor updates for dev dependencies",
-      "matchDepTypes": ["devDependencies"],
-      "matchUpdateTypes": ["minor"],
+      "description": "Automerge all minor and patch updates",
+      "matchUpdateTypes": ["minor", "patch"],
       "automerge": true
     }
   ]


### PR DESCRIPTION
## Summary

Reduces Renovate PR noise in SDK repo by:
1. **Adding groupings** - ai-sdks, typescript-tools, database (matching SMRT config)
2. **Automerging minor updates** - not just dev deps, all minor updates now automerge

## Changes

| Aspect | Before | After |
|--------|--------|-------|
| Minor prod deps | Manual review | Automerge |
| Groupings | None | ai-sdks, typescript-tools, database |
| Expected PR noise | High | Lower (grouped + automerged) |

## Notes

- Major updates still require manual review (conservative)
- Svelte grouping not added (SDK doesn't use Svelte)