### PR TITLE
fix: exclude @happyvertical packages from catch-all group

### DIFF
--- a/default.json
+++ b/default.json
@@ -50,10 +50,11 @@
   "dependencyDashboardAutoclose": false,
   "packageRules": [
     {
-      "description": "Group all non-major updates into a single PR",
+      "description": "Group all non-major updates into a single PR (excludes @happyvertical packages which have their own grouping)",
       "groupName": "all dependencies",
       "groupSlug": "all-dependencies",
       "matchPackagePatterns": ["*"],
+      "excludePackagePatterns": ["^@happyvertical/"],
       "matchUpdateTypes": ["minor", "patch", "pin", "digest", "pinDigest"]
     }
   ]


### PR DESCRIPTION
## Summary
- Exclude `@happyvertical/` scoped packages from the catch-all "all dependencies" group in default.json

## Problem
The catch-all rule in `default.json` was matching `@happyvertical/*` packages, which prevented the SDK-specific grouping rules in `smrt.json` from working correctly. This caused:
- Individual PRs being created for each SDK package (e.g., separate PRs for `@happyvertical/ai`, `@happyvertical/sql`, etc.)
- Instead of a single grouped "HappyVertical SDK" PR as intended

## Solution
Add `excludePackagePatterns: ["^@happyvertical/"]` to the catch-all rule, allowing:
- `smrt.json` to properly group SDK packages as "HappyVertical SDK"
- `sdk.json` to handle SDK repo's own dependencies separately
- Each repo's specific config to control how @happyvertical packages are grouped

## Test plan
- [x] Config syntax is valid JSON
- [ ] Next SDK release should create a grouped "HappyVertical SDK" PR in SMRT repo instead of individual PRs