### PR TITLE
fix(smrt): simplify SDK dependency grouping and automerge

### DIFF
--- a/smrt.json
+++ b/smrt.json
@@ -13,27 +13,17 @@
   "labels": ["dependencies", "renovate", "smrt"],
   "packageRules": [
     {
-      "description": "Group @happyvertical SDK packages (all non-smrt packages)",
+      "description": "Group and automerge @happyvertical SDK packages",
       "matchPackagePatterns": ["^@happyvertical/(?!smrt-)"],
       "groupName": "HappyVertical SDK",
       "groupSlug": "happyvertical-sdk",
-      "labels": ["dependencies", "sdk", "upstream"]
-    },
-    {
-      "description": "Automerge SDK patch updates",
-      "matchPackagePatterns": ["^@happyvertical/(?!smrt-)"],
-      "matchUpdateTypes": ["patch"],
+      "labels": ["dependencies", "sdk", "upstream"],
+      "separateMajorMinor": false,
+      "separateMultipleMajor": false,
       "automerge": true
     },
     {
-      "description": "SDK major/minor updates need review",
-      "matchPackagePatterns": ["^@happyvertical/(?!smrt-)"],
-      "matchUpdateTypes": ["major", "minor"],
-      "automerge": false,
-      "labels": ["dependencies", "sdk", "upstream", "needs-review"]
-    },
-    {
-      "description": "Automerge all other patch updates",
+      "description": "Automerge all patch updates",
       "matchUpdateTypes": ["patch"],
       "automerge": true
     },


### PR DESCRIPTION
## Summary

Fixes the issue where SDK packages were getting individual branches (`renovate/happyvertical-ai-0.x`) instead of being grouped into a single `HappyVertical SDK` PR.

## Changes

- Add `separateMajorMinor: false` and `separateMultipleMajor: false` to the SDK grouping rule to prevent version-line separation
- Consolidate three separate SDK package rules into one rule that groups and automerges all updates
- Remove manual review requirement for major/minor updates - CI will catch any failures

## Root Cause

The base config has `separateMajorMinor: true` and `separateMultipleMajor: true`. For 0.x packages, this was causing each SDK package to get its own branch (version-line branches like `-0.x`).

## Expected Behavior After Merge

SDK packages will be grouped into a single PR with branch `renovate/happyvertical-sdk` that automerges after CI passes.

## Test Plan

1. Merge this PR
2. Trigger Renovate to run on SMRT repo (check the Dependency Dashboard checkbox)
3. Verify SDK packages are now grouped in a single PR