### PR TITLE
feat: enable aggressive auto-merge for minor/patch updates

### DIFF
--- a/default.json
+++ b/default.json
@@ -25,10 +25,13 @@
   "commitMessageTopic": "{{depName}}",
   "commitMessageExtra": "to {{#if isPinDigest}}{{{newDigestShort}}}{{else}}{{#if isMajor}}{{prettyNewMajor}}{{else}}{{#if isSingleVersion}}{{prettyNewVersion}}{{else}}{{#if newValue}}{{{newValue}}}{{else}}{{{newDigestShort}}}{{/if}}{{/if}}{{/if}}{{/if}}",
   "branchPrefix": "renovate/",
+  "minor": {
+    "automerge": true,
+    "automergeType": "branch"
+  },
   "patch": {
     "automerge": true,
-    "automergeType": "pr",
-    "automergeStrategy": "squash"
+    "automergeType": "branch"
   },
   "vulnerabilityAlerts": {
     "enabled": true,
@@ -50,7 +53,13 @@
   "dependencyDashboardAutoclose": false,
   "packageRules": [
     {
-      "description": "Group all non-major updates into a single PR (excludes @happyvertical packages which have their own grouping)",
+      "description": "Auto-merge pin and digest updates without PRs",
+      "matchUpdateTypes": ["pin", "digest", "pinDigest"],
+      "automerge": true,
+      "automergeType": "branch"
+    },
+    {
+      "description": "Group all non-major updates (excludes @happyvertical packages which have their own grouping)",
       "groupName": "all dependencies",
       "groupSlug": "all-dependencies",
       "matchPackagePatterns": ["*"],


### PR DESCRIPTION
## Summary
- Change `automergeType` from `"pr"` to `"branch"` for patch updates
- Add `minor` block with automerge enabled (branch type)
- Add package rule for pin/digest updates to auto-merge without PRs

## How It Works
- **Patch/Minor/Pin/Digest**: Renovate pushes directly to main → CI runs → if it fails, you see it in CI
- **Major**: Creates PR → you review → merge manually

This reduces PR buildup across all repos using the org-wide config.

## Test Plan
- [ ] Merge this PR to renovate-config
- [ ] Wait for Renovate CE to pick up the new config
- [ ] Check any repo's Dependency Dashboard
- [ ] Confirm patch/minor updates push directly without PRs
- [ ] Confirm major updates still create PRs