### PR TITLE
feat: automerge GitHub Actions major updates

### DIFF
--- a/default.json
+++ b/default.json
@@ -70,6 +70,13 @@
       "automergeType": "branch"
     },
     {
+      "description": "Automerge GitHub Actions major updates (use integer versions like v4, v5)",
+      "matchManagers": ["github-actions"],
+      "matchUpdateTypes": ["major"],
+      "automerge": true,
+      "automergeType": "branch"
+    },
+    {
       "description": "Group all non-major updates (excludes @happyvertical packages which have their own grouping)",
       "groupName": "all dependencies",
       "groupSlug": "all-dependencies",


### PR DESCRIPTION
## Summary

Adds automerge rule for GitHub Actions major version updates.

GitHub Actions use integer versions (v4, v5, v6) which Renovate classifies as "major" updates. Since these are stable and backward-compatible by convention, this change automerges them like other safe updates.

## Changes

Added to `default.json`:
```json
{
  "description": "Automerge GitHub Actions major updates (use integer versions like v4, v5)",
  "matchManagers": ["github-actions"],
  "matchUpdateTypes": ["major"],
  "automerge": true,
  "automergeType": "branch"
}
```

## Affected PRs

After merge, the following PRs should be automerged:
- happyvertical/sdk#776: update actions/download-artifact to v7
- happyvertical/sdk#777: update GitHub Artifact Actions to v5
- happyvertical/sdk#778: update GitHub Artifact Actions to v6

Closes #7