### PR TITLE
[codex] move Renovate to weekly dependency PR

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,9 +18,11 @@ Shareable [Renovate](https://docs.renovatebot.com/) configuration for the HappyV
 | `sites` | Web sites | happyvertical.com, bangblow.com |
 | `client` | External organizations | Client orgs using @happyvertical/* |
 
-### Dependency Grouping Presets
+### Dependency Labeling Presets
 
-| Preset | Packages Grouped |
+These presets add targeted labels without splitting the weekly organization PR.
+
+| Preset | Packages Labeled |
 |--------|------------------|
 | `groups/ai-sdks` | OpenAI, Anthropic, Google GenAI, LangChain, MCP |
 | `groups/typescript-tools` | TypeScript, Vite, Vitest, Biome, Turbo, Changesets |
@@ -89,9 +91,9 @@ If you're using `@happyvertical/*` packages in your project, you can use our cli
 ```
 
 This preset will:
-- Group all `@happyvertical/*` packages together
-- Automerge patch updates
-- Require review for major updates
+- Create one weekly dependency update PR on Saturday night
+- Label `@happyvertical/*` package updates
+- Require review before merging updates
 - Configure GitHub Packages registry
 
 **Note:** You need a GitHub token with `read:packages` scope to fetch `@happyvertical/*` packages from GitHub Packages.
@@ -100,40 +102,35 @@ This preset will:
 
 ### Base Settings (`default.json`)
 
-- **Schedule**: Manual triggers via Dependency Dashboard (empty schedule)
-- **Automerge**: All patch updates
-- **PR Limits**: 4/hour, 10 concurrent
+- **Schedule**: Saturday night, 9 PM-midnight `America/Edmonton`
+- **Grouping**: One `weekly dependency update` PR for dependency updates
+- **Automerge**: Disabled for normal dependency update PRs
+- **PR Limits**: 1/hour, 1 concurrent PR, 1 concurrent branch
 - **Commit Format**: `chore(deps): update {package} to {version}`
 - **Branch Prefix**: `renovate/`
 - **Labels**: `dependencies`, `renovate`
 - **Vulnerability Alerts**: Always enabled
+- **Standalone Lockfile Maintenance**: Disabled in the pnpm preset to avoid a second PR
 
 ### Layer Strategies
 
 | Layer | Version Strategy | Automerge |
 |-------|-----------------|-----------|
-| SDK | Pin all versions | Patches only |
-| SMRT | Pin SDK, bump others | Patches + SDK patches |
-| Applications | Semver ranges (bump) | All patches |
-| Sites | Semver ranges | All patches |
+| SDK | Pin all versions | Disabled |
+| SMRT | Pin SDK, bump others | Disabled |
+| Applications | Semver ranges (bump) | Disabled |
+| Sites | Semver ranges | Disabled |
 
-### Enabling Automatic Updates
+### Schedule Overrides
 
-The default schedule is manual (via Dependency Dashboard). To enable automatic updates, add a schedule to your config:
+The default schedule is already enabled for HappyVertical repos. Override it only when a repository needs an explicit exception:
 
 ```json
 {
-  "extends": [
-    "local>happyvertical/renovate-config:sdk",
-    "schedule:weekly"
-  ]
+  "extends": ["local>happyvertical/renovate-config:sdk"],
+  "schedule": ["* 0-3 * * 0"]
 }
 ```
-
-Available schedules:
-- `schedule:weekly` - Monday mornings
-- `schedule:monthly` - First Monday of month
-- `schedule:nonOfficeHours` - Outside business hours
 
 ## Repository Structure
 

--- a/README_AUTOMERGE.md
+++ b/README_AUTOMERGE.md
@@ -1,39 +1,21 @@
-# Automerge Configuration
+# Dependency Update Strategy
 
 ## Current Behavior
 
-- **Minor & Patch**: Automerge without PR
-- **Major**: Create PR for review
+- **Cadence**: One weekly PR on Saturday night, 9 PM-midnight `America/Edmonton`
+- **Grouping**: Major, minor, patch, pin, and digest updates share the `weekly dependency update` PR
+- **Automerge**: Disabled for normal dependency update PRs
 - **Vulnerability Alerts**: Always create PR (never automerge)
+- **Standalone Lockfile Maintenance**: Disabled for pnpm repos to avoid a second PR
 
-## Automerging Major Updates
+## Allowing Repository Exceptions
 
-To automerge major updates for specific packages (e.g., packages with frequent major releases or integer versioning), add them to the `matchPackageNames` array in `default.json`:
+Prefer keeping repository exceptions narrow. If a repository needs a temporary update stream for a specific package, add a local `packageRules` entry in that repository:
 
 ```json
 {
-  "description": "Automerge major updates for packages with frequent major releases",
-  "matchPackageNames": [
-    "@types/node",
-    "@types/react",
-    "typescript-eslint"
-  ],
-  "matchUpdateTypes": ["major"],
-  "automerge": true,
-  "automergeType": "branch"
+  "description": "Hold this package for manual dashboard approval",
+  "matchPackageNames": ["example-package"],
+  "dependencyDashboardApproval": true
 }
-```
-
-### Common Candidates
-
-Packages that often have non-breaking major updates:
-- `@types/*` - TypeScript type definitions
-- `@eslint/*` - ESLint core and plugins
-- `eslint-plugin-*` - ESLint plugins
-- `prettier-plugin-*` - Prettier plugins
-- Build tools with calendar-based versioning
-
-You can also use patterns:
-```json
-"matchPackagePatterns": ["^@types/", "^eslint-plugin-", "^prettier-plugin-"]
 ```

--- a/application.json
+++ b/application.json
@@ -12,25 +12,14 @@
   "labels": ["dependencies", "renovate", "application"],
   "packageRules": [
     {
-      "description": "Group @happyvertical SDK packages (all non-smrt packages)",
+      "description": "Label @happyvertical SDK packages (all non-smrt packages)",
       "matchPackagePatterns": ["^@happyvertical/(?!smrt-)"],
-      "groupName": "HappyVertical SDK",
-      "groupSlug": "happyvertical-sdk",
       "labels": ["dependencies", "sdk", "upstream"]
     },
     {
-      "description": "Group @happyvertical/smrt-* packages (framework)",
+      "description": "Label @happyvertical/smrt-* packages (framework)",
       "matchPackagePatterns": ["^@happyvertical/smrt-"],
-      "groupName": "SMRT Framework",
-      "groupSlug": "smrt-framework",
       "labels": ["dependencies", "smrt", "upstream"]
-    },
-    {
-      "description": "Automerge all @happyvertical updates (internal packages, always safe)",
-      "matchPackagePatterns": ["^@happyvertical/"],
-      "automerge": true,
-      "automergeType": "pr",
-      "platformAutomerge": true
     },
     {
       "description": "Use semver ranges in applications",
@@ -38,23 +27,21 @@
       "rangeStrategy": "bump"
     },
     {
-      "description": "Automerge all patch updates",
-      "matchUpdateTypes": ["patch"],
-      "automerge": true
-    },
-    {
-      "description": "Group Crawlee ecosystem",
+      "description": "Label Crawlee ecosystem",
       "matchPackagePatterns": ["^crawlee", "^@crawlee/"],
-      "groupName": "Crawlee",
-      "groupSlug": "crawlee",
       "labels": ["dependencies", "scraping"]
     },
     {
-      "description": "Group web scraping tools",
+      "description": "Label web scraping tools",
       "matchPackageNames": ["cheerio", "jsdom", "playwright", "happy-dom"],
-      "groupName": "Web Scraping",
-      "groupSlug": "web-scraping",
       "labels": ["dependencies", "scraping"]
+    },
+    {
+      "description": "Keep application dependency updates in the weekly organization PR",
+      "matchPackageNames": ["*"],
+      "groupName": "weekly dependency update",
+      "groupSlug": "weekly-dependency-update",
+      "automerge": false
     }
   ]
 }

--- a/client.json
+++ b/client.json
@@ -7,21 +7,31 @@
     ":semanticCommitTypeAll(chore)"
   ],
   "npmrc": "@happyvertical:registry=https://npm.pkg.github.com",
+  "labels": ["dependencies", "renovate"],
+  "timezone": "America/Edmonton",
+  "prHourlyLimit": 1,
+  "prConcurrentLimit": 1,
+  "branchConcurrentLimit": 1,
+  "groupName": "weekly dependency update",
+  "groupSlug": "weekly-dependency-update",
+  "separateMajorMinor": false,
+  "separateMinorPatch": false,
+  "separateMultipleMajor": false,
+  "separateMultipleMinor": false,
+  "schedule": ["* 21-23 * * 6"],
+  "updateNotScheduled": false,
   "packageRules": [
     {
-      "description": "Group all @happyvertical packages together",
+      "description": "Label @happyvertical packages",
       "matchPackagePatterns": ["^@happyvertical/"],
-      "groupName": "HappyVertical Packages",
-      "groupSlug": "happyvertical",
       "labels": ["dependencies", "happyvertical"]
     },
     {
-      "description": "Automerge all @happyvertical updates (internal packages, always safe)",
-      "matchPackagePatterns": ["^@happyvertical/"],
-      "automerge": true,
-      "automergeType": "pr",
-      "automergeStrategy": "squash",
-      "platformAutomerge": true
+      "description": "Keep client dependency updates in the weekly organization PR",
+      "matchPackageNames": ["*"],
+      "groupName": "weekly dependency update",
+      "groupSlug": "weekly-dependency-update",
+      "automerge": false
     }
   ]
 }

--- a/default.json
+++ b/default.json
@@ -18,20 +18,22 @@
   ],
   "npmrc": "//npm.pkg.github.com/:_authToken=${NPM_TOKEN}\n@happyvertical:registry=https://npm.pkg.github.com",
   "labels": ["dependencies", "renovate"],
-  "prHourlyLimit": 4,
-  "prConcurrentLimit": 10,
+  "timezone": "America/Edmonton",
+  "prHourlyLimit": 1,
+  "prConcurrentLimit": 1,
+  "branchConcurrentLimit": 1,
   "commitMessagePrefix": "chore(deps):",
   "commitMessageAction": "update",
   "commitMessageTopic": "{{depName}}",
   "commitMessageExtra": "to {{#if isPinDigest}}{{{newDigestShort}}}{{else}}{{#if isMajor}}{{prettyNewMajor}}{{else}}{{#if isSingleVersion}}{{prettyNewVersion}}{{else}}{{#if newValue}}{{{newValue}}}{{else}}{{{newDigestShort}}}{{/if}}{{/if}}{{/if}}{{/if}}",
   "branchPrefix": "renovate/",
+  "groupName": "weekly dependency update",
+  "groupSlug": "weekly-dependency-update",
   "minor": {
-    "automerge": true,
-    "automergeType": "branch"
+    "automerge": false
   },
   "patch": {
-    "automerge": true,
-    "automergeType": "branch"
+    "automerge": false
   },
   "major": {
     "automerge": false
@@ -47,42 +49,24 @@
     "**/docs/node_modules/**"
   ],
   "pinDigests": true,
-  "separateMajorMinor": true,
-  "separateMultipleMajor": true,
-  "schedule": [],
+  "separateMajorMinor": false,
+  "separateMinorPatch": false,
+  "separateMultipleMajor": false,
+  "separateMultipleMinor": false,
+  "schedule": ["* 21-23 * * 6"],
+  "updateNotScheduled": false,
   "dependencyDashboard": true,
   "dependencyDashboardTitle": "Dependency Dashboard",
   "dependencyDashboardHeader": "This issue contains a list of all dependencies that can be updated. Click a checkbox to create a PR for that update.",
   "dependencyDashboardAutoclose": false,
   "packageRules": [
     {
-      "description": "Auto-merge pin and digest updates without PRs",
-      "matchUpdateTypes": ["pin", "digest", "pinDigest"],
-      "automerge": true,
-      "automergeType": "branch"
-    },
-    {
-      "description": "Automerge major updates for TypeScript definitions and tools with frequent major releases",
-      "matchPackagePatterns": ["^@types/", "^eslint-plugin-", "^prettier-plugin-"],
-      "matchPackageNames": ["typescript-eslint"],
-      "matchUpdateTypes": ["major"],
-      "automerge": true,
-      "automergeType": "branch"
-    },
-    {
-      "description": "Automerge GitHub Actions major updates (use integer versions like v4, v5)",
-      "matchManagers": ["github-actions"],
-      "matchUpdateTypes": ["major"],
-      "automerge": true,
-      "automergeType": "branch"
-    },
-    {
-      "description": "Group all non-major updates (excludes @happyvertical packages which have their own grouping)",
-      "groupName": "all dependencies",
-      "groupSlug": "all-dependencies",
-      "matchPackagePatterns": ["*"],
-      "excludePackagePatterns": ["^@happyvertical/"],
-      "matchUpdateTypes": ["minor", "patch", "pin", "digest", "pinDigest"]
+      "description": "Create one Saturday-night dependency update PR",
+      "matchPackageNames": ["*"],
+      "matchUpdateTypes": ["major", "minor", "patch", "pin", "digest", "pinDigest"],
+      "groupName": "weekly dependency update",
+      "groupSlug": "weekly-dependency-update",
+      "automerge": false
     }
   ]
 }

--- a/groups/ai-sdks.json
+++ b/groups/ai-sdks.json
@@ -3,38 +3,28 @@
   "description": "AI SDK dependency grouping",
   "packageRules": [
     {
-      "description": "Group OpenAI SDK updates",
+      "description": "Label OpenAI SDK updates",
       "matchPackageNames": ["openai"],
-      "groupName": "OpenAI SDK",
-      "groupSlug": "openai-sdk",
       "labels": ["dependencies", "ai"]
     },
     {
-      "description": "Group Anthropic SDK updates",
+      "description": "Label Anthropic SDK updates",
       "matchPackagePatterns": ["^@anthropic-ai/"],
-      "groupName": "Anthropic SDK",
-      "groupSlug": "anthropic-sdk",
       "labels": ["dependencies", "ai"]
     },
     {
-      "description": "Group Google GenAI SDK updates",
+      "description": "Label Google GenAI SDK updates",
       "matchPackageNames": ["@google/genai", "@google/generative-ai"],
-      "groupName": "Google GenAI SDK",
-      "groupSlug": "google-genai-sdk",
       "labels": ["dependencies", "ai"]
     },
     {
-      "description": "Group LangChain updates",
+      "description": "Label LangChain updates",
       "matchPackagePatterns": ["^@langchain/", "^langchain"],
-      "groupName": "LangChain",
-      "groupSlug": "langchain",
       "labels": ["dependencies", "ai"]
     },
     {
-      "description": "Group MCP SDK updates",
+      "description": "Label MCP SDK updates",
       "matchPackagePatterns": ["^@modelcontextprotocol/"],
-      "groupName": "MCP SDK",
-      "groupSlug": "mcp-sdk",
       "labels": ["dependencies", "ai"]
     }
   ]

--- a/groups/aws-sdks.json
+++ b/groups/aws-sdks.json
@@ -3,12 +3,9 @@
   "description": "AWS SDK dependency grouping",
   "packageRules": [
     {
-      "description": "Group all AWS SDK v3 packages",
+      "description": "Label AWS SDK v3 packages",
       "matchPackagePatterns": ["^@aws-sdk/"],
-      "groupName": "AWS SDK v3",
-      "groupSlug": "aws-sdk-v3",
-      "labels": ["dependencies", "aws"],
-      "schedule": ["before 9am on monday"]
+      "labels": ["dependencies", "aws"]
     }
   ]
 }

--- a/groups/database.json
+++ b/groups/database.json
@@ -3,31 +3,23 @@
   "description": "Database dependency grouping",
   "packageRules": [
     {
-      "description": "Group LibSQL/Turso client",
+      "description": "Label LibSQL/Turso client updates",
       "matchPackagePatterns": ["^@libsql/"],
-      "groupName": "LibSQL Client",
-      "groupSlug": "libsql",
       "labels": ["dependencies", "database"]
     },
     {
-      "description": "Group PostgreSQL clients",
+      "description": "Label PostgreSQL client updates",
       "matchPackageNames": ["pg", "@types/pg", "postgres"],
-      "groupName": "PostgreSQL",
-      "groupSlug": "postgresql",
       "labels": ["dependencies", "database"]
     },
     {
-      "description": "Group better-sqlite3",
+      "description": "Label better-sqlite3 updates",
       "matchPackageNames": ["better-sqlite3", "@types/better-sqlite3"],
-      "groupName": "better-sqlite3",
-      "groupSlug": "better-sqlite3",
       "labels": ["dependencies", "database"]
     },
     {
-      "description": "Group DuckDB",
+      "description": "Label DuckDB updates",
       "matchPackagePatterns": ["^duckdb", "^@duckdb/"],
-      "groupName": "DuckDB",
-      "groupSlug": "duckdb",
       "labels": ["dependencies", "database"]
     }
   ]

--- a/groups/googleapis.json
+++ b/groups/googleapis.json
@@ -3,13 +3,10 @@
   "description": "Google APIs dependency grouping",
   "packageRules": [
     {
-      "description": "Group all googleapis packages together",
+      "description": "Label googleapis updates",
       "matchPackagePatterns": ["^googleapis", "^@googleapis/"],
-      "groupName": "googleapis",
-      "groupSlug": "googleapis",
       "separateMultipleMajor": false,
-      "labels": ["dependencies", "google"],
-      "schedule": ["before 9am on monday"]
+      "labels": ["dependencies", "google"]
     }
   ]
 }

--- a/groups/svelte.json
+++ b/groups/svelte.json
@@ -3,10 +3,8 @@
   "description": "Svelte ecosystem dependency grouping",
   "packageRules": [
     {
-      "description": "Group Svelte core",
+      "description": "Label Svelte core updates",
       "matchPackagePatterns": ["^svelte$", "^svelte-", "^@sveltejs/"],
-      "groupName": "Svelte",
-      "groupSlug": "svelte",
       "labels": ["dependencies", "svelte"]
     }
   ]

--- a/groups/typescript-tools.json
+++ b/groups/typescript-tools.json
@@ -3,52 +3,38 @@
   "description": "TypeScript tooling dependency grouping",
   "packageRules": [
     {
-      "description": "Group TypeScript and related tooling",
+      "description": "Label TypeScript and related tooling updates",
       "matchPackageNames": ["typescript", "tsx", "ts-node"],
-      "groupName": "TypeScript",
-      "groupSlug": "typescript",
       "labels": ["dependencies", "typescript"]
     },
     {
-      "description": "Group Vite ecosystem",
+      "description": "Label Vite ecosystem updates",
       "matchPackagePatterns": ["^vite$", "^vite-", "^@vitejs/"],
-      "groupName": "Vite",
-      "groupSlug": "vite",
       "labels": ["dependencies", "build"]
     },
     {
-      "description": "Group Vitest ecosystem",
+      "description": "Label Vitest ecosystem updates",
       "matchPackagePatterns": ["^vitest$", "^@vitest/"],
-      "groupName": "Vitest",
-      "groupSlug": "vitest",
       "labels": ["dependencies", "testing"]
     },
     {
-      "description": "Group Biome (linting/formatting)",
+      "description": "Label Biome updates",
       "matchPackagePatterns": ["^@biomejs/"],
-      "groupName": "Biome",
-      "groupSlug": "biome",
       "labels": ["dependencies", "tooling"]
     },
     {
-      "description": "Group TypeDoc",
+      "description": "Label TypeDoc updates",
       "matchPackagePatterns": ["^typedoc", "^typedoc-plugin-"],
-      "groupName": "TypeDoc",
-      "groupSlug": "typedoc",
       "labels": ["dependencies", "docs"]
     },
     {
-      "description": "Group Changesets",
+      "description": "Label Changesets updates",
       "matchPackagePatterns": ["^@changesets/"],
-      "groupName": "Changesets",
-      "groupSlug": "changesets",
       "labels": ["dependencies", "release"]
     },
     {
-      "description": "Group Turbo",
+      "description": "Label Turbo updates",
       "matchPackageNames": ["turbo"],
-      "groupName": "Turborepo",
-      "groupSlug": "turbo",
       "labels": ["dependencies", "build"]
     }
   ]

--- a/pnpm.json
+++ b/pnpm.json
@@ -5,8 +5,7 @@
     "local>happyvertical/renovate-config"
   ],
   "lockFileMaintenance": {
-    "enabled": true,
-    "schedule": ["before 9am on monday"]
+    "enabled": false
   },
   "postUpdateOptions": ["pnpmDedupe"],
   "allowedPostUpgradeCommands": ["^pnpm"],

--- a/sdk.json
+++ b/sdk.json
@@ -17,9 +17,11 @@
       "rangeStrategy": "replace"
     },
     {
-      "description": "Automerge minor and patch updates",
-      "matchUpdateTypes": ["minor", "patch"],
-      "automerge": true
+      "description": "Keep SDK dependency updates in the weekly organization PR",
+      "matchPackageNames": ["*"],
+      "groupName": "weekly dependency update",
+      "groupSlug": "weekly-dependency-update",
+      "automerge": false
     }
   ]
 }

--- a/sites.json
+++ b/sites.json
@@ -9,30 +9,19 @@
   "labels": ["dependencies", "renovate", "sites"],
   "packageRules": [
     {
-      "description": "Group SST packages",
+      "description": "Label SST packages",
       "matchPackageNames": ["sst"],
-      "groupName": "SST",
-      "groupSlug": "sst",
       "labels": ["dependencies", "deployment"]
     },
     {
-      "description": "Group Tailwind ecosystem",
+      "description": "Label Tailwind ecosystem",
       "matchPackagePatterns": ["^tailwindcss", "^@tailwindcss/", "autoprefixer", "postcss"],
-      "groupName": "Tailwind CSS",
-      "groupSlug": "tailwindcss",
       "labels": ["dependencies", "css"]
     },
     {
-      "description": "Group Shiki (syntax highlighting)",
+      "description": "Label Shiki updates",
       "matchPackageNames": ["shiki"],
-      "groupName": "Shiki",
-      "groupSlug": "shiki",
       "labels": ["dependencies", "syntax"]
-    },
-    {
-      "description": "Automerge patch updates",
-      "matchUpdateTypes": ["patch"],
-      "automerge": true
     },
     {
       "description": "Ignore link: dependencies (local development)",
@@ -43,6 +32,13 @@
       "description": "Ignore file: dependencies",
       "matchCurrentValue": "/^file:/",
       "enabled": false
+    },
+    {
+      "description": "Keep site dependency updates in the weekly organization PR",
+      "matchPackageNames": ["*"],
+      "groupName": "weekly dependency update",
+      "groupSlug": "weekly-dependency-update",
+      "automerge": false
     }
   ]
 }

--- a/smrt.json
+++ b/smrt.json
@@ -13,33 +13,28 @@
   "labels": ["dependencies", "renovate", "smrt"],
   "packageRules": [
     {
-      "description": "Group and automerge @happyvertical SDK packages",
+      "description": "Label @happyvertical SDK packages",
       "matchPackagePatterns": ["^@happyvertical/(?!smrt-)"],
-      "groupName": "HappyVertical SDK",
-      "groupSlug": "happyvertical-sdk",
       "labels": ["dependencies", "sdk", "upstream"],
       "separateMajorMinor": false,
-      "separateMultipleMajor": false,
-      "automerge": true
+      "separateMultipleMajor": false
     },
     {
-      "description": "Automerge all patch updates",
-      "matchUpdateTypes": ["patch"],
-      "automerge": true
-    },
-    {
-      "description": "Group HTML parsing libraries",
+      "description": "Label HTML parsing libraries",
       "matchPackageNames": ["cheerio", "jsdom", "htmlparser2", "happy-dom"],
-      "groupName": "HTML Parsing",
-      "groupSlug": "html-parsing",
       "labels": ["dependencies", "parsing"]
     },
     {
-      "description": "Group glob utilities",
+      "description": "Label glob utilities",
       "matchPackageNames": ["fast-glob", "minimatch", "glob"],
-      "groupName": "Glob Utilities",
-      "groupSlug": "glob",
       "labels": ["dependencies", "utils"]
+    },
+    {
+      "description": "Keep SMRT dependency updates in the weekly organization PR",
+      "matchPackageNames": ["*"],
+      "groupName": "weekly dependency update",
+      "groupSlug": "weekly-dependency-update",
+      "automerge": false
     }
   ]
 }


### PR DESCRIPTION
## Summary

Moves the shared HappyVertical Renovate presets to a weekly dependency release train:

- schedules normal dependency updates for Saturday night, 9 PM-midnight America/Edmonton
- limits Renovate to one hourly PR, one concurrent PR, and one concurrent branch
- groups normal major/minor/patch/pin/digest updates into `weekly dependency update`
- disables normal dependency automerge and standalone pnpm lockfile maintenance
- converts package-specific grouping presets into labeling presets so they do not split the weekly PR
- updates the Renovate config docs to match the new strategy

## Validation

- `jq . default.json pnpm.json sdk.json smrt.json application.json sites.json client.json groups/*.json`
- `git diff --check`
- Confirmed changed option names exist in the current Renovate schema from `https://docs.renovatebot.com/renovate-schema.json`

Note: Renovate's own transient validator install failed before config validation because the `npx renovate` install hit package resolution/cache extraction errors locally.