### PR TITLE
feat: add org-standards preset locking the shared toolchain

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,14 +41,27 @@ repo on its next run, and each repo's own CI validates it.
 
 Current standards:
 
-| Tool | Version | Covers |
-|------|---------|--------|
-| Node | 24.18.0 | `engines.node`, `.nvmrc`, `node` Docker images, `node-version:` pins in workflows and composite actions |
-| pnpm | 11.13.0 | `packageManager`, `engines.pnpm` |
+| Tool | Version | Strategy | Covers |
+|------|---------|----------|--------|
+| Node | 24.18.0 | bump ranges | `engines.node`, `.nvmrc`, `node` Docker images, `node-version:` pins in workflows and composite actions |
+| pnpm | 11.13.0 | bump ranges | `packageManager`, `engines.pnpm` |
+| TypeScript | 5.9.3 | pin exact | blocks TS 6/7 this wave |
+| Vitest | 4.1.10 | pin exact | `vitest` and `@vitest/*` in lockstep |
+| Vite | 8.1.4 | pin exact | |
+| SvelteKit | 2.69.3 | pin exact | |
+| Biome | 2.5.3 | pin exact | |
+| Turbo | 2.10.5 | pin exact | |
+| Lefthook | 2.1.10 | pin exact | |
 
-Caveats: Renovate never downgrades (a repo hand-bumped above a cap must be
-fixed manually), and it cannot add a missing pin — repos without a
-`packageManager` field need it added once by hand before the rules apply.
+The blanket `rangeStrategy: bump` rules in `pnpm.json` and `application.json`
+exclude the pinned tools so the pins are not overridden (later-resolving
+package rules win in Renovate).
+
+Caveats: Renovate never downgrades (repos already above a cap — e.g. on
+TypeScript 6 — must be brought back manually), it cannot add a missing pin
+(repos without a `packageManager` field need it added once by hand), and the
+`client` preset does not extend `default`, so repos on it do not inherit these
+standards.
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ Shareable [Renovate](https://docs.renovatebot.com/) configuration for the HappyV
 | Preset | Description | Use Case |
 |--------|-------------|----------|
 | `default` | Base configuration with common settings | Extended by all other presets |
+| `org-standards` | Org-standard toolchain versions (Node, pnpm) | Extended by `default`; applies everywhere |
 | `monorepo` | Monorepo settings (handles `workspace:*`) | SDK, SMRT |
 | `pnpm` | pnpm-specific configuration | Most repos |
 | `bun` | Bun-specific configuration | IAC repo |
@@ -29,6 +30,25 @@ These presets add targeted labels without splitting the weekly organization PR.
 | `groups/aws-sdks` | @aws-sdk/* packages |
 | `groups/database` | LibSQL, PostgreSQL, better-sqlite3, DuckDB |
 | `groups/svelte` | Svelte, SvelteKit, Svelte plugins |
+
+### Org-standard toolchain versions
+
+`org-standards.json` is the single knob for org-wide toolchain versions.
+Each rule caps a tool with `allowedVersions`; every repo converges on the cap
+and holds there. To roll out a new standard (e.g. a new Node or pnpm version),
+bump the cap in `org-standards.json` — Renovate opens the bump PR in every
+repo on its next run, and each repo's own CI validates it.
+
+Current standards:
+
+| Tool | Version | Covers |
+|------|---------|--------|
+| Node | 24.18.0 | `engines.node`, `.nvmrc`, `node` Docker images, `node-version:` pins in workflows and composite actions |
+| pnpm | 11.13.0 | `packageManager`, `engines.pnpm` |
+
+Caveats: Renovate never downgrades (a repo hand-bumped above a cap must be
+fixed manually), and it cannot add a missing pin — repos without a
+`packageManager` field need it added once by hand before the rules apply.
 
 ## Usage
 

--- a/application.json
+++ b/application.json
@@ -22,8 +22,17 @@
       "labels": ["dependencies", "smrt", "upstream"]
     },
     {
-      "description": "Use semver ranges in applications",
-      "matchPackagePatterns": ["*"],
+      "description": "Use semver ranges in applications, except org-standard tools which stay pinned (see org-standards.json)",
+      "matchPackageNames": [
+        "!typescript",
+        "!vitest",
+        "!@vitest/**",
+        "!vite",
+        "!@sveltejs/kit",
+        "!@biomejs/biome",
+        "!turbo",
+        "!lefthook"
+      ],
       "rangeStrategy": "bump"
     },
     {

--- a/default.json
+++ b/default.json
@@ -7,7 +7,8 @@
     ":semanticCommitTypeAll(chore)",
     ":preserveSemverRanges",
     "group:monorepos",
-    "group:recommended"
+    "group:recommended",
+    "local>happyvertical/renovate-config:org-standards"
   ],
   "hostRules": [
     {

--- a/org-standards.json
+++ b/org-standards.json
@@ -1,0 +1,40 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "description": "Org-standard toolchain versions. Each rule caps a tool at the org standard via allowedVersions; bumping a cap here rolls the new standard out to every repo on the next Renovate run. Renovate never downgrades, so a repo pinned above a cap must be fixed manually.",
+  "packageRules": [
+    {
+      "description": "Org standard: Node 24.18.0 (engines, .nvmrc, node Docker images, workflow node-version pins)",
+      "matchDepNames": ["node"],
+      "allowedVersions": "<=24.18.0",
+      "rangeStrategy": "bump"
+    },
+    {
+      "description": "Org standard: pnpm 11.13.0 (packageManager and engines)",
+      "matchDepNames": ["pnpm"],
+      "allowedVersions": "<=11.13.0",
+      "rangeStrategy": "bump"
+    }
+  ],
+  "customManagers": [
+    {
+      "customType": "regex",
+      "description": "Track same-line node-version pins in workflow and composite-action YAML",
+      "managerFilePatterns": ["/^\\.github/(workflows|actions)/.+\\.ya?ml$/"],
+      "matchStrings": [
+        "node-version:\\s*['\"]?(?<currentValue>\\d+\\.\\d+\\.\\d+)['\"]?\\s*$"
+      ],
+      "depNameTemplate": "node",
+      "datasourceTemplate": "node-version"
+    },
+    {
+      "customType": "regex",
+      "description": "Track node-version input defaults in composite actions",
+      "managerFilePatterns": ["/^\\.github/actions/.+\\.ya?ml$/"],
+      "matchStrings": [
+        "node-version:\\s*\\n\\s+description:[^\\n]*\\n(?:\\s+required:[^\\n]*\\n)?\\s+default:\\s*['\"](?<currentValue>\\d+\\.\\d+\\.\\d+)['\"]"
+      ],
+      "depNameTemplate": "node",
+      "datasourceTemplate": "node-version"
+    }
+  ]
+}

--- a/org-standards.json
+++ b/org-standards.json
@@ -13,6 +13,48 @@
       "matchDepNames": ["pnpm"],
       "allowedVersions": "<=11.13.0",
       "rangeStrategy": "bump"
+    },
+    {
+      "description": "Org standard: TypeScript 5.9.3 this wave (blocks TS 6/7; repos already above the cap must be downgraded manually)",
+      "matchPackageNames": ["typescript"],
+      "allowedVersions": "<=5.9.3",
+      "rangeStrategy": "pin"
+    },
+    {
+      "description": "Org standard: Vitest 4.1.10 (@vitest/* kept in lockstep)",
+      "matchPackageNames": ["vitest", "@vitest/**"],
+      "allowedVersions": "<=4.1.10",
+      "rangeStrategy": "pin"
+    },
+    {
+      "description": "Org standard: Vite 8.1.4",
+      "matchPackageNames": ["vite"],
+      "allowedVersions": "<=8.1.4",
+      "rangeStrategy": "pin"
+    },
+    {
+      "description": "Org standard: SvelteKit 2.69.3",
+      "matchPackageNames": ["@sveltejs/kit"],
+      "allowedVersions": "<=2.69.3",
+      "rangeStrategy": "pin"
+    },
+    {
+      "description": "Org standard: Biome 2.5.3",
+      "matchPackageNames": ["@biomejs/biome"],
+      "allowedVersions": "<=2.5.3",
+      "rangeStrategy": "pin"
+    },
+    {
+      "description": "Org standard: Turbo 2.10.5",
+      "matchPackageNames": ["turbo"],
+      "allowedVersions": "<=2.10.5",
+      "rangeStrategy": "pin"
+    },
+    {
+      "description": "Org standard: Lefthook 2.1.10",
+      "matchPackageNames": ["lefthook"],
+      "allowedVersions": "<=2.1.10",
+      "rangeStrategy": "pin"
     }
   ],
   "customManagers": [

--- a/pnpm.json
+++ b/pnpm.json
@@ -16,7 +16,18 @@
   },
   "packageRules": [
     {
+      "description": "Bump ranges, except org-standard tools which stay pinned (see org-standards.json)",
       "matchManagers": ["npm"],
+      "matchPackageNames": [
+        "!typescript",
+        "!vitest",
+        "!@vitest/**",
+        "!vite",
+        "!@sveltejs/kit",
+        "!@biomejs/biome",
+        "!turbo",
+        "!lefthook"
+      ],
       "rangeStrategy": "bump"
     }
   ]


### PR DESCRIPTION
Adds an `org-standards` preset as the single knob for org-wide toolchain versions, extended by `default` so every repo inherits it. Companion to happyvertical/sdk#1090 and the runner-image work in happyvertical/iac#957.

## Standards
| Tool | Version | Strategy |
|------|---------|----------|
| Node | 24.18.0 | bump ranges (engines, .nvmrc, Docker images, workflow `node-version:` pins via customManagers) |
| pnpm | 11.13.0 | bump ranges (packageManager, engines) |
| TypeScript | 5.9.3 | pin exact — blocks TS 6/7 this wave |
| Vitest | 4.1.10 | pin exact, `@vitest/*` in lockstep |
| Vite | 8.1.4 | pin exact |
| SvelteKit | 2.69.3 | pin exact |
| Biome | 2.5.3 | pin exact |
| Turbo | 2.10.5 | pin exact |
| Lefthook | 2.1.10 | pin exact |

## How it works
- Each rule caps a tool with `allowedVersions`; repos below the cap get bump/pin PRs (majors included) until they converge, then hold. Rolling out a new standard = bumping the cap here.
- The blanket `rangeStrategy: bump` rules in `pnpm.json` and `application.json` resolve after `org-standards` and would override the pins, so the pinned tools are carved out of them.
- Updates ride the existing Saturday weekly grouped PR; the pnpm preset's `postUpgradeTasks` regenerates lockfiles; each repo's own CI validates its migration.

## Known limits (documented in README)
- Renovate never downgrades: **spider** and **amaru.ca** are already on TypeScript ^6.0.3 and need manual downgrades to 5.9.3.
- It can't add missing pins: repos without a `packageManager` field need a one-time manual add.
- The `client` preset intentionally doesn't get the standards (external orgs extend it) — but **magnateos.com** and **ergot.io** use it, so they won't inherit until switched to an org preset.
- `sdk.json` keeps engines on `rangeStrategy: replace` (its existing rule), so engine floors in sdk/svelte repos won't auto-bump — caps still apply.

Validated with `renovate-config-validator` against all four changed files.