### PR TITLE
fix(application): migrate invalid package matchers

### DIFF
--- a/application.json
+++ b/application.json
@@ -13,12 +13,12 @@
   "packageRules": [
     {
       "description": "Label @happyvertical SDK packages (all non-smrt packages)",
-      "matchPackagePatterns": ["^@happyvertical/(?!smrt-)"],
+      "matchPackageNames": ["@happyvertical/*", "!@happyvertical/smrt-*"],
       "labels": ["dependencies", "sdk", "upstream"]
     },
     {
       "description": "Label @happyvertical/smrt-* packages (framework)",
-      "matchPackagePatterns": ["^@happyvertical/smrt-"],
+      "matchPackageNames": ["@happyvertical/smrt-*"],
       "labels": ["dependencies", "smrt", "upstream"]
     },
     {
@@ -37,7 +37,7 @@
     },
     {
       "description": "Label Crawlee ecosystem",
-      "matchPackagePatterns": ["^crawlee", "^@crawlee/"],
+      "matchPackageNames": ["crawlee*", "@crawlee/*"],
       "labels": ["dependencies", "scraping"]
     },
     {


### PR DESCRIPTION
Closes #12

Migrates the shared application preset from deprecated `matchPackagePatterns` to current `matchPackageNames` globs, preserving SDK/SMRT/Crawlee classification without unsupported regex lookahead.

Validation: current `renovate-config-validator --strict --no-global application.json`; four independent review passes clean.

<!-- hv-agent-run:v1 -->
{"schema":"hv-agent-run:v1","runtime":"codex","session":"codex-12-migrate-application-matchers-20260729","issue":"12","policy_revision":"1.0.0","validation":["current strict Renovate config validation passed","four independent review passes reported CLEAN"]}